### PR TITLE
feat(plugins): load plugins early and keymap for diffview open

### DIFF
--- a/lua/config/options.lua
+++ b/lua/config/options.lua
@@ -1,7 +1,7 @@
 vim.g.loaded_netrw = 1       -- Disables the default Netrw file explorer
 vim.g.loaded_netrwPlugin = 1 -- Disables the Netrw plugin, using neotree instead
 vim.opt.termguicolors = true -- Enables 24-bit RGB color support in the terminal
-
+vim.o.autoread = true
 vim.g.mapleader = ' '        -- sets space as leader key
 vim.g.maplocalleader = ' '
 

--- a/lua/plugins/git.lua
+++ b/lua/plugins/git.lua
@@ -67,6 +67,7 @@ return {
     dependencies = {
       'nvim-lua/plenary.nvim',
       'nvim-tree/nvim-web-devicons' },
+    event = "BufRead",
     keys = {
       { "<leader>jj", "<cmd>set hidden<cr><cmd>DiffviewClose<cr><cmd>set nohidden<cr>" },
     },
@@ -78,6 +79,7 @@ return {
       "sindrets/diffview.nvim",        -- optional - Diff integration
       "nvim-telescope/telescope.nvim", -- optional
     },
+    event = "BufRead",
     config = function()
       require('neogit').setup({
         commit_popup = {
@@ -87,6 +89,28 @@ return {
           diffview = true,
         },
       })
+      vim.keymap.set('n', '<leader>do', function()
+        -- Verwende Telescope, um Branches auszuwählen
+        require('telescope.builtin').git_branches({
+          attach_mappings = function(_, map)
+            map('i', '<CR>', function(prompt_bufnr)
+              local actions = require('telescope.actions')
+              local state = require('telescope.actions.state')
+              local selection = state.get_selected_entry(prompt_bufnr)
+              actions.close(prompt_bufnr)
+
+              -- Überprüfen, ob ein Branch ausgewählt wurde
+              if selection and selection.value then
+                -- Diffview öffnen mit dem Branch-Kontext
+                vim.cmd("DiffviewOpen " .. selection.value)
+              else
+                print("Abgebrochen: Kein Branch ausgewählt.")
+              end
+            end)
+            return true
+          end,
+        })
+      end, { noremap = true, silent = true, desc = "Diffview: Open diff for current file and branch" })
     end,
     keys = {
       { "<leader>gg", "<cmd>Neogit<cr>", desc = "Neogit", noremap = true, silent = true },


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enabled automatic file reading in Neovim when files are changed externally.
	- Added activation for Git-related plugins upon reading a buffer.
	- Introduced a new key mapping (`<leader>do`) to open a diff view for the current file and branch using Telescope.

- **Bug Fixes**
	- Improved file handling capabilities to ensure users see the most current version of files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->